### PR TITLE
Added headless option

### DIFF
--- a/config.example
+++ b/config.example
@@ -55,6 +55,8 @@ UPDATE_USERNAME=you
 UPDATE_TOKEN=yourtoken
 UPDATE_EXPERIMENTAL=0
 UPDATE_TMPDIR=/tmp
+# Set to 1 to enable download of the headless updates
+HEADLESS=0
 
 # Extras
 # Additional binary arguments, these will be sent to the biary when issuing the "start" command

--- a/factorio
+++ b/factorio
@@ -260,7 +260,11 @@ update(){
   if ! [ -z $1 ]; then #lazy --dry-run check ;)
     dryrun="--dry-run"
   fi
-  package="core-linux`get_bin_arch`"
+  if [ ${HEADLESS} -gt 0 ]; then
+    package="core-linux_headless`get_bin_arch`"
+  else
+    package="core-linux`get_bin_arch`"
+  fi
   version=`get_bin_version`
   if [ -z "${UPDATE_TMPDIR}" ]; then
     UPDATE_TMPDIR=/tmp


### PR DESCRIPTION
Trying to do an update on a headless server resulted in failure since package was specified as core-linux64 when it needed to be core-linux_headless64. This should fix that for those that use the init.d script. The syntax may need to be looked over since I haven't had a chance to thoroughly test it yet, but when I ran it, it reported that there were "No new updates for core-linux_headless64 0.12.15" when HEADLESS=1 was set in the config, so it appears to be working.
