### PR TITLE
Remove username and token from update script

### DIFF
--- a/config.example
+++ b/config.example
@@ -51,8 +51,6 @@ PACKAGE_DIR_NAME=factorio
 # absolute path to the factorio-updater script
 UPDATE_SCRIPT=/path/to/update-factorio.py
 # See https://github.com/narc0tiq/factorio-updater for details regarding the options
-UPDATE_USERNAME=you
-UPDATE_TOKEN=yourtoken
 UPDATE_EXPERIMENTAL=0
 UPDATE_TMPDIR=/tmp
 # Set to 1 to enable download of the headless updates

--- a/factorio
+++ b/factorio
@@ -275,7 +275,7 @@ update(){
     UPDATE_TMPDIR=/tmp
   fi
   tmpdir="${UPDATE_TMPDIR}/factorio-update"
-  invocation="python ${UPDATE_SCRIPT} --user ${UPDATE_USERNAME} --token ${UPDATE_TOKEN} --for-version ${version} --package ${package} --output-path ${tmpdir}"
+  invocation="python ${UPDATE_SCRIPT} --for-version ${version} --package ${package} --output-path ${tmpdir}"
   if [ ${UPDATE_EXPERIMENTAL} -gt 0 ]; then
     invocation="${invocation} --experimental"
   fi


### PR DESCRIPTION
The updater no longer needs a username and token. Steam users will not have one. I believe this simplifies the setup and will reduce confusion.
