### PR TITLE
Use $FACTORIO_PATH in config example

### DIFF
--- a/config.example
+++ b/config.example
@@ -17,7 +17,7 @@ FACTORIO_PATH=/path/to/factorio
 # The absolute path to the factorio binary
 BINARY=${FACTORIO_PATH}/bin/x64/factorio
 # Absolute path to factorios config.ini
-FCONF=/path/to/factorio/config/config.ini
+FCONF=${FACTORIO_PATH}/config/config.ini
 # Port on which you want to run the server
 PORT=34197
 


### PR DESCRIPTION
By default, the `config.ini` file is generated in a folder named "config" two directory levels above the factorio binary. This means that by default, the config.ini file is at `${FACTORIO_PATH}/config/config.ini`.

Changing this in the config.example `factorio-init` configuration files means less for the end user to change when setting up `factorio-init`.
