### PR TITLE
Update config.exemple

### DIFF
--- a/config.example
+++ b/config.example
@@ -17,7 +17,7 @@ FACTORIO_PATH=/path/to/factorio
 # The absolute path to the factorio binary
 BINARY=${FACTORIO_PATH}/bin/x64/factorio
 # Absolute path to factorios config.ini
-FCONF=/path/to/factorio/config/config.ini
+FCONF=${FACTORIO_PATH}/config/config.ini
 # Port on which you want to run the server
 PORT=34197
 


### PR DESCRIPTION
Hi,

You forgot to change "/path/to/factorio" to "${FACTORIO_PATH}" .

Another thing, when the script couldn't find the config.ini it tells you to execute this command: "sudo -u /opt/factorio/bin/x64/factorio --start-server factorio-init-save". But when this save file doesn't exist, the game won't create the config folder and config.init. You'll have to run: "sudo -u /opt/factorio/bin/x64/factorio --create factorio-init-save" to make it work.

Thanks,
Arend-Jan
