### PR TITLE
Add map gen settings argument to new-game command

### DIFF
--- a/factorio
+++ b/factorio
@@ -112,24 +112,24 @@ usage(){
   echo "Usage: $0 COMMAND"
   echo
   echo "Available commands:"
-  echo -e "   start \t\t Starts the server"
-  echo -e "   stop \t\t Stops the server"
-  echo -e "   restart \t\t Restarts the server"
-  echo -e "   status \t\t Displays server status"
-  echo -e "   players-online \t Shows online players"
-  echo -e "   players \t\t Shows all players"
-  echo -e "   cmd [command/message] Open interactive commandline or send a single command to the server"
-  echo -e "   chatlog [--tail|-t]   Print the current chatlog, optionally tail the log to follow in real time"
-  echo -e "   new-game name\t Stops the server and creates a new game with the specified name"
-  echo -e "   save-game name \t Stops the server and saves game to specified save"
-  echo -e "   load-save name \t Stops the server and loads the specified save"
-  echo -e "   install tarball \t Installs the server with specified tarball"
-  echo -e "   update [--dry-run] \t Updates the server"
-  echo -e "   invocation \t\t Outputs the invocation for debugging purpose"
-  echo -e "   listcommands \t List all init-commands"
-  echo -e "   listsaves \t\t List all saves"
-  echo -e "   version \t\t Prints the binary version"
-  echo -e "   help \t\t Shows this help message"
+  echo -e "   start \t\t\t\t Starts the server"
+  echo -e "   stop \t\t\t\t Stops the server"
+  echo -e "   restart \t\t\t\t Restarts the server"
+  echo -e "   status \t\t\t\t Displays server status"
+  echo -e "   players-online \t\t\t Shows online players"
+  echo -e "   players \t\t\t\t Shows all players"
+  echo -e "   cmd [command/message] \t\t Open interactive commandline or send a single command to the server"
+  echo -e "   chatlog [--tail|-t] \t\t\t Print the current chatlog, optionally tail the log to follow in real time"
+  echo -e "   new-game name [map-gen-settings] \t Stops the server and creates a new game with the specified name using the specified map gen settings json file"
+  echo -e "   save-game name \t\t\t Stops the server and saves game to specified save"
+  echo -e "   load-save name \t\t\t Stops the server and loads the specified save"
+  echo -e "   install tarball \t\t\t Installs the server with specified tarball"
+  echo -e "   update [--dry-run] \t\t\t Updates the server"
+  echo -e "   invocation \t\t\t\t Outputs the invocation for debugging purpose"
+  echo -e "   listcommands \t\t\t List all init-commands"
+  echo -e "   listsaves \t\t\t\t List all saves"
+  echo -e "   version \t\t\t\t Prints the binary version"
+  echo -e "   help \t\t\t\t Shows this help message"
 }
 
 ME=`whoami`
@@ -564,6 +564,17 @@ case "$1" in
       exit 1
     fi
     savename="${WRITE_DIR}/saves/$2"
+    createsavecmd="$BINARY --create ${savename}"
+
+    # Check if user wants to use custom map gen settings
+    if [ $3 ]; then
+      if [ -e "${WRITE_DIR}/$3" ]; then
+        createsavecmd="$createsavecmd --map-gen-settings=${WRITE_DIR}/$3"
+      else
+        echo "Specified map gen settings json does not exist"
+        exit 1
+      fi
+    fi
 
     # Stop Service
     if is_running; then
@@ -574,7 +585,7 @@ case "$1" in
       fi
     fi
 
-    if ! as_user "$BINARY --create ${savename}"; then
+    if ! as_user "$createsavecmd"; then
       echo "Failed to create new game"
       exit 1
     else


### PR DESCRIPTION
Allows user to specify the path to a map gen settings json file as a
second argument to the new-game command. Path is relative to the write
dir. Checks to see if the file exists before attempting.
