### PR TITLE
Updated for 0.14.12, added config option to load specific map

### DIFF
--- a/config.example
+++ b/config.example
@@ -17,13 +17,20 @@ FACTORIO_PATH=/opt/factorio
 # Server settings file, see data/server-settings.example.json
 SERVER_SETTINGS=${FACTORIO_PATH}/data/server-settings.json
 
+# The path to your save file. If undefined, uses --start-server-load-latest.
+#SAVE_PATH=${FACTORIO_PATH}/saves/map.zip
+
+# Overrides any other --start-server* arguments, use for scenarios etc
+#START_SERVER_ARG=--start-server-load-latest
+
 # Port on which you want to run the server
 PORT=34197
 
-# The number of minutes between each autosave
-AUTOSAVE_INTERVAL=10
-# The number of autosaves to use for rotation
-AUTOSAVE_SLOTS=3
+# Deprecated since 0.14.12, define them in your server-settings.json instead
+## The number of minutes between each autosave
+##AUTOSAVE_INTERVAL=10
+## The number of autosaves to use for rotation
+##AUTOSAVE_SLOTS=3
 
 # Save the command/chat/log on server start? Default location /opt/factorio/server.out 
 # Setting this to 0 will cause the script to erase the log file on each start

--- a/factorio
+++ b/factorio
@@ -103,8 +103,16 @@ if ! [ "$1" == "install" ]; then
     SAVELOG=0
   fi
 
+  if [ -z "${START_SERVER_ARG}" ]; then
+    if [ -z "${SAVE_PATH}" ]; then
+      START_SERVER_ARG="--start-server-load-latest"
+    else
+      START_SERVER_ARG="--start-server ${SAVE_PATH}"
+    fi
+  fi
+
   # Finally, set up the invocation
-  INVOCATION="${BINARY} --config ${FCONF} --port ${PORT} --start-server-load-latest --server-settings ${SERVER_SETTINGS} --autosave-interval ${AUTOSAVE_INTERVAL} --autosave-slots ${AUTOSAVE_SLOTS} ${RCON} ${EXTRA_BINARGS}"
+  INVOCATION="${BINARY} ${START_SERVER_ARG} --config ${FCONF} --port ${PORT} --server-settings ${SERVER_SETTINGS} ${RCON} ${EXTRA_BINARGS}"
 
 fi
 


### PR DESCRIPTION
0.14.12 removed the `--autosave-interval` and `--autosave-slots` command line switches, see https://forums.factorio.com/viewtopic.php?f=3&t=3359

Also added SAVE_PATH and START_SERVER_ARG config options for loading a specific map or replacing the `--start-server*` argument altogether.
