### PR TITLE
Removed the autosave parameters due to the removal of them in 0.14.1x

### DIFF
--- a/factorio
+++ b/factorio
@@ -104,7 +104,7 @@ if ! [ "$1" == "install" ]; then
   fi
 
   # Finally, set up the invocation
-  INVOCATION="${BINARY} --config ${FCONF} --port ${PORT} --start-server-load-latest --server-settings ${SERVER_SETTINGS} --autosave-interval ${AUTOSAVE_INTERVAL} --autosave-slots ${AUTOSAVE_SLOTS} ${RCON} ${EXTRA_BINARGS}"
+  INVOCATION="${BINARY} --config ${FCONF} --port ${PORT} --start-server-load-latest --server-settings ${SERVER_SETTINGS} ${RCON} ${EXTRA_BINARGS}"
 
 fi
 


### PR DESCRIPTION
Hi, I found my server not able to start after one of the recent patches - factorio was complaining about the unused parameters.
