### PR TITLE
add a command to allowing source'ing the script to import vars etc.

### DIFF
--- a/factorio
+++ b/factorio
@@ -716,6 +716,10 @@ case "$1" in
   version)
     echo `get_bin_version`
     ;;
+  source)
+    # do not call `exit` and just return successfully, so that other scripts (possibly with set -e) may source this script to import all out variables and functions
+    return 0
+    ;;
   *)
     echo "No such command!"
     echo


### PR DESCRIPTION
This adds the command 'source' that prevents the final call to `exit`
by just returning successfully (i.e. `return 0`), so that other scripts
(possibly with `set -e`) may source this script and thus import all our
variables and functions. This makes the logic for finding important
factorio files and all functions defined in this script easily reusable.
By calling `exit`, other scripts using `source` to import this script
would be terminated.

This can be seen when running the following snippet
(which will never print "post-source with other arg"):
```
#!/usr/bin/env bash

set -e

echo "pre-source with source arg"
source factorio source
echo "post-source with source arg"

echo "$CMDOUT"

echo "pre-source with other arg"
source factorio version
echo "post-source with other arg"

echo "$CMDOUT"
```