### PR TITLE
correctly determine beginning and end of cmd output in send_cmd

### DIFF
--- a/factorio
+++ b/factorio
@@ -243,20 +243,20 @@ stop_service() {
 send_cmd(){
   if is_running; then
     if [ -p ${FIFO} ]; then
-      cmdid="FACTORIO_INIT_CMD_DELIMITER"
-      # Whisper that unknown player
-      echo "/w ${cmdid}" > ${FIFO}
-      # Wait for factorio to read stdin
-      sleep 1
+      # Generate two unique log markers
+      TIMESTAMP=$(date +"%s")
+      START="FACTORIO_INIT_CMD_${TIMESTAMP}_START"
+      END="FACTORIO_INIT_CMD_${TIMESTAMP}_END"
+
+      # Whisper that unknown player to place start marker in log
+      echo "/w $START" > ${FIFO}
       # Run the actual command
       echo $@ > ${FIFO}
-      # Wait again, this might need more sleep for larger command output - time will tell (sorry future self for any head aches)
-      sleep 1
-      # Read the output file backwards - capture everything between the end of file until
-      # factorio tells us our random command id player does not exist.
-      # This also attempts to filter all non chat/command lines from the output
-      response=$(sed "/Player ${cmdid} doesn't exist./q" <(tac ${CMDOUT}) |egrep -v "(${cmdid})|${NONCMDPATTERN}")
-      echo "${response}"
+      # Whisper that unknown player again to place end marker in log after the command terminated
+      echo "/w $END" > ${FIFO}
+
+      # search for the start marker in the log file, then follow and print the log output in real time until the end marker is found
+      awk "/Player $START doesn't exist./{flag=1;next}/Player $END doesn't exist./{exit}flag" <(stdbuf -i0 -o0 tail -F ${CMDOUT} 2> /dev/null)
     else
       echo "${FIFO} is not a pipe!"
       return 1


### PR DESCRIPTION
and return output in correct order instead of in reverse.

Instead of relying on the command being complete after 1 second and then going through the log in reverse to find the beginning, we now place two unique beginning and end markers in the log file.
This allows us to
- read the log file in the correct order
- get all output of the command in real time, even if it takes a little longer to complete
- return immediately if the command completes early, instead of always waiting for a constant time of 2 seconds
- prevent head aches for future self

Please note that:
- this still won't filter out output which is not generated by the sent command (which is not possible without factorio tagging its output)
- the NONCMDPATTERN filter is no longer included as it should be optional (at least in my opinion).
  Hint: to filter out any garbage such as empty lines, server debug output and these markers, the following code could be used (in this case in tail_chatlog, as the output generated by send_cmd between the markers is also removed)
```
    stdbuf -i0 -o0 tail -F -n 0 ${CMDOUT}\
     | stdbuf -i0 -o0 sed "/^\s*$/d"\
     | stdbuf -i0 -o0 egrep -v "${NONCMDPATTERN}"\
     | stdbuf -i0 -o0 egrep -v "Player FACTORIO_INIT_CMD_DELIMITER doesn't exist."\
     | stdbuf -i0 -o0 awk -v flag=1 "/Player FACTORIO_INIT_CMD_[0-9]+_START doesn't exist./{flag=0}\
        /Player FACTORIO_INIT_CMD_[0-9]+_END doesn't exist./{flag=1;next}\
        flag"
```

This also fixes #116 