### PR TITLE
Ensure update tmpdir is created securely and cleaned up automatically

### DIFF
--- a/factorio
+++ b/factorio
@@ -437,7 +437,14 @@ update(){
     UPDATE_TMPDIR=/tmp
   fi
 
-  tmpdir="${UPDATE_TMPDIR}/factorio-update"
+  # Create tmpdir and ensure automatic cleanup
+  tmpdir=`as_user "mktemp -p ${UPDATE_TMPDIR} factorio-update.XXXXXXXXXX"`
+  if [ $? -ne 0 ]; then
+    echo "Aborting update! Unable to create tmpdir: ${tmpdir}"
+    exit 1
+  fi
+  trap "rm -rf ${tmpdir}" EXIT
+    
   invocation="python ${UPDATE_SCRIPT} --for-version ${version} --package ${package} --output-path ${tmpdir}"
   if [ ${UPDATE_EXPERIMENTAL} -gt 0 ]; then
     invocation="${invocation} --experimental"
@@ -478,21 +485,9 @@ update(){
     exit 0
   fi
 
-  if [ -e ${tmpdir} ]; then
-    echo "Aborting update! Temporary directory already exists ${tmpdir}"
-    echo "Remnants from a previously failed update?"
-    exit 1
-  fi
-
-  if ! as_user "mkdir -p ${tmpdir}"; then
-    echo "Aborting update! Unable to create tmpdir: ${tmpdir}"
-    exit 1
-  fi
-
   # Time to download the updates
   if ! as_user "${invocation}"; then
     echo "Aborting update!"
-    rm -rf ${tmpdir}
     exit 1
   fi
 
@@ -524,7 +519,6 @@ update(){
   fi
 
   echo "Successfully updated factorio"
-  rm -rf ${tmpdir}
 }
 
 case "$1" in


### PR DESCRIPTION
Current temporary directory creation is predictable and non-atomic. Therefore, it's not secure. It is possible for another user to pre-create the directory and poison it's contents. Using mktemp avoids this vulnerability.

Also, the conditional logic requires a copy of the cleanup command at the end of every place where installation may abort after temporary directory creation. It is better to set up a trap on EXIT in one place immediately after directory creation. Thus, additional changes to conditional logic can't accidentally omit correct cleanup logic.