### PR TITLE
Don't wait on output when it isn't needed. The server may be paused.

### DIFF
--- a/factorio
+++ b/factorio
@@ -255,6 +255,11 @@ stop_service() {
 }
 
 send_cmd(){
+  NEED_OUTPUT=0
+  if [ "xx$1" == "xx-o" ]; then
+    NEED_OUTPUT=1
+    shift
+  fi
   if is_running; then
     if [ -p ${FIFO} ]; then
       # Generate two unique log markers
@@ -269,8 +274,11 @@ send_cmd(){
       # Whisper that unknown player again to place end marker in log after the command terminated
       echo "/w $END" > ${FIFO}
 
-      # search for the start marker in the log file, then follow and print the log output in real time until the end marker is found
-      awk "/Player $START doesn't exist./{flag=1;next}/Player $END doesn't exist./{exit}flag" <(stdbuf -i0 -o0 tail -F ${CMDOUT} 2> /dev/null)
+      if [ ${NEED_OUTPUT} -eq 1 ]; then
+        # search for the start marker in the log file, then follow and print the log output in real time until the end marker is found
+        sleep 1
+        awk "/Player $START doesn't exist./{flag=1;next}/Player $END doesn't exist./{exit}flag" < ${CMDOUT}
+      fi
     else
       echo "${FIFO} is not a pipe!"
       return 1
@@ -282,7 +290,7 @@ send_cmd(){
 }
 
 cmd_players(){
-  players=$(send_cmd "/p")
+  players=$(send_cmd -o "/p")
   if [ -z "${players}" ]; then
     echo "No players found!"
     return 1


### PR DESCRIPTION
If the game server is paused, the log won't be updated with the magic strings generated by send_cmd, and the script will hang until the server in unpaused.

This is particularly deleterious in the event of a system shutdown while the game server is paused. The init script will hang trying to send players a helpful message and ultimately fail to ever send the TERM signal to the game server. Without the signal, the game server won't shutdown cleanly and won't save the current game state before the system goes down. The next time the server comes up, the game will be reverted to the last autosave.

This patch changes send_cmd so that it only waits for output if the -o option is passed, such as when a list of players is requested. When simply posting helpful messages to players, send_cmd will never block.