### PR TITLE
Wait until pingpong servers are reachable before starting factorio

### DIFF
--- a/config.example
+++ b/config.example
@@ -32,6 +32,11 @@ PORT=34197
 # If you set this to 1 you might want to apply logrotate on the log or it will eventually fill your disk
 SAVELOG=0
 
+# Delay starting the game server until the we confirm the pingpong servers are reachable.
+# This makes sure that game server detects the correct external IP in a NAT setup.
+# Useful for Cloud providers where VMs may start faster than their Internet connectivity is plumbed.
+WAIT_PINGPONG=0
+
 # Factorio comes packaged in a tarball containing the directory named "factorio"
 # when using this scripts update/install command we expect to see this very
 # directory. If you want to supply your own update/install tar other than what you can download

--- a/factorio
+++ b/factorio
@@ -178,6 +178,11 @@ is_running() {
   return 1
 }
 
+wait_pingpong() {
+  until ping -c1 pingpong1.factorio.com &>/dev/null; do :; done
+  until ping -c1 pingpong2.factorio.com &>/dev/null; do :; done
+}
+
 start_service() {
   if [ -e ${PIDFILE} ]; then
     ps -p $(cat ${PIDFILE}) > /dev/null 2>&1
@@ -198,6 +203,8 @@ start_service() {
     debug "Erasing log ${CMDOUT}"
     echo "" > ${CMDOUT}
   fi
+
+  wait_pingpong
 
   as_user "tail -f ${FIFO} |${INVOCATION} ${EXE_ARGS_GLIBC}>> ${CMDOUT} 2>&1 & echo \$! > ${PIDFILE}"
 

--- a/factorio
+++ b/factorio
@@ -57,6 +57,9 @@ fi
 if [ -z ${ALT_GLIBC} ]; then
   ALT_GLIBC=0
 fi
+if [ -z ${WAIT_PINGPONG} ]; then
+  WAIT_PINGPONG=0
+fi
 
 if [ ${ALT_GLIBC} -gt 0 ]; then
   # If ALT_GLIBC is non 0 then activate alternative glibc root here
@@ -204,7 +207,9 @@ start_service() {
     echo "" > ${CMDOUT}
   fi
 
-  wait_pingpong
+  if [ ${WAIT_PINGPONG} -gt 0 ]; then
+    wait_pingpong
+  fi
 
   as_user "tail -f ${FIFO} |${INVOCATION} ${EXE_ARGS_GLIBC}>> ${CMDOUT} 2>&1 & echo \$! > ${PIDFILE}"
 


### PR DESCRIPTION
Before listing a multiplayer game on the matching server, the Factorio game server tries to contact "pingpong" servers to determine its external IP in case it's behind some sort of NAT. When launching a Factorio server on a  cloud provider, it's possible for the game server to start before virtual networking has been fully plumbed. The game server will fail to contact either pingpong server, and will list the incorrect IP on the matching server, generally the internal RFC 1918 IP of the VM rather than the dynamically allocated, ephemeral, Internet routable IP to which the cloud provider will transparently perform a static NAT.

Currently, the game servier will never retry to contact the pingpong servers and will never update it's IP on the matching server after starting. As a workaround, this script optionally delays startup of the game server until the pingpong servers are reachable. This is only meaningful for Internet accessible servers, as private servers without Internet reachability will fail to complete startup.

https://www.factorio.com/blog/post/fff-143