### PR TITLE
Changed way to get version and arch information

### DIFF
--- a/factorio
+++ b/factorio
@@ -424,11 +424,11 @@ install(){
 }
 
 get_bin_version(){
-  echo $(as_user '$BINARY --version') |egrep '^Version: [0-9\.]+' |egrep -o '[0-9\.]+' |head -n 1
+  echo "$(as_user '$BINARY --version')" |egrep '^Version: [0-9\.]+' |egrep -o '[0-9\.]+' |head -n 1
 }
 
 get_bin_arch(){
-  echo $(as_user '$BINARY --version') |egrep '^Binary version: ' |egrep -o '[0-9]{2}'
+  echo "$(as_user '$BINARY --version')" |egrep '^Binary version: ' |egrep -o '[0-9]{2}'
 }
 
 update(){

--- a/factorio
+++ b/factorio
@@ -424,11 +424,11 @@ install(){
 }
 
 get_bin_version(){
-  echo `as_user "$BINARY --version |egrep '^Version: [0-9\.]+' |egrep -o '[0-9\.]+' |head -n 1"`
+  echo $(as_user '$BINARY --version') |egrep '^Version: [0-9\.]+' |egrep -o '[0-9\.]+' |head -n 1
 }
 
 get_bin_arch(){
-  echo `as_user "$BINARY --version |egrep '^Binary version: ' |egrep -o '[0-9]{2}'"`
+  echo $(as_user '$BINARY --version') |egrep '^Binary version: ' |egrep -o '[0-9]{2}'
 }
 
 update(){


### PR DESCRIPTION
On CentOS 7 in very specific circumstances where SELINUX is enabled, the version number parsing gets mangled between contexts with egrep output ignored and can be exasperated depending on the values provided in the "extra arguments"

Get the output of the whole version string running the factorio binary as the user, but parse the output after it comes back to the script as the script user, rather than in the factorio user.