### PR TITLE
Update init script to support new server-adminlist.json config file

### DIFF
--- a/config.example
+++ b/config.example
@@ -24,6 +24,15 @@ FACTORIO_PATH=/opt/factorio
 # Server settings file, see data/server-settings.example.json
 SERVER_SETTINGS=${FACTORIO_PATH}/data/server-settings.json
 
+# Server admin settings
+# Server admin list file, must be in the following format:
+# [
+#    admin1,
+#    admin2,
+#    adminX
+# ]
+ADMINLIST=${FACTORIO_PATH}/data/server-adminlist.json
+
 # Port on which you want to run the server
 PORT=34197
 

--- a/config.example
+++ b/config.example
@@ -31,6 +31,7 @@ SERVER_SETTINGS=${FACTORIO_PATH}/data/server-settings.json
 #    admin2,
 #    adminX
 # ]
+# If the file does not exist in ${FACTORIO_PATH}/data, a blank copy will be created.
 ADMINLIST=${FACTORIO_PATH}/data/server-adminlist.json
 
 # Port on which you want to run the server

--- a/factorio
+++ b/factorio
@@ -123,7 +123,7 @@ case "$1" in
     fi
   
     # Finally, set up the invocation
-    INVOCATION="${BINARY} --config ${FCONF} --port ${PORT} --start-server-load-latest --server-settings ${SERVER_SETTINGS} ${EXTRA_BINARGS}"
+    INVOCATION="${BINARY} --config ${FCONF} --port ${PORT} --start-server-load-latest --server-settings ${SERVER_SETTINGS} ${EXTRA_BINARGS} --server-adminlist ${ADMINLIST}"
     ;;
 esac
   
@@ -205,6 +205,11 @@ start_service() {
   if [ "${SAVELOG}" ==  "0" ]; then
     debug "Erasing log ${CMDOUT}"
     echo "" > ${CMDOUT}
+  fi
+
+  if ! [ -e ${ADMINLIST} ]; then
+    debug "${ADMINLIST} does not exist!  Creating empty file."
+    echo "[]" > ${ADMINLIST}
   fi
 
   if [ ${WAIT_PINGPONG} -gt 0 ]; then

--- a/factorio
+++ b/factorio
@@ -123,7 +123,7 @@ case "$1" in
     fi
   
     # Finally, set up the invocation
-    INVOCATION="${BINARY} --config ${FCONF} --port ${PORT} --start-server-load-latest --server-settings ${SERVER_SETTINGS} ${EXTRA_BINARGS} --server-adminlist ${ADMINLIST}"
+    INVOCATION="${BINARY} --config ${FCONF} --port ${PORT} --start-server-load-latest --server-settings ${SERVER_SETTINGS} --server-adminlist ${ADMINLIST} ${EXTRA_BINARGS}"
     ;;
 esac
   

--- a/factorio
+++ b/factorio
@@ -210,6 +210,7 @@ start_service() {
   if ! [ -e ${ADMINLIST} ]; then
     debug "${ADMINLIST} does not exist!  Creating empty file."
     echo "[]" > ${ADMINLIST}
+    chown ${USERNAME}:${USERGROUP} ${ADMINLIST}
   fi
 
   if [ ${WAIT_PINGPONG} -gt 0 ]; then


### PR DESCRIPTION
This PR is to address the 0.17.x update splitting the definition of server admin users from server-settings.json into a new file, named server-adminlist.json, as discussed here: 
 https://forums.factorio.com/viewtopic.php?f=23&t=65548&p=403122&hilit=server+settings.json#p403122.

This is also briefly mentioned on the Factorio wiki here:  https://wiki.factorio.com/Multiplayer#Miscellaneous_Tips