### PR TITLE
Chaned exit code of 'update'

### DIFF
--- a/factorio
+++ b/factorio
@@ -490,7 +490,7 @@ update(){
 
   if [ -z "${newversion}" ]; then
     echo "No new updates for ${package} ${version}"
-    exit 0
+    exit 1
   else
     echo "New version ${package} ${newversion}"
   fi


### PR DESCRIPTION
Chaned exit code of 'update'  when there is no new version to make it posible to let an update check run all lets say 30 min and react on the exit code of the dry run