### PR TITLE
Get map-settings and map-gen-settings in /data

### DIFF
--- a/factorio
+++ b/factorio
@@ -656,9 +656,9 @@ case "$1" in
     # Check if user wants to use custom map gen settings
     if [ $3 ]; then
       if [ -e "${WRITE_DIR}/$3" ]; then
-        createsavecmd="$createsavecmd --map-gen-settings=${WRITE_DIR}/$3"
+        createsavecmd="$createsavecmd --map-gen-settings=${WRITE_DIR}/data/$3"
       else
-        echo "Specified map gen settings json does not exist"
+        echo "Specified map-gen-settings json does not exist in server's /data directory"
         exit 1
       fi
     fi
@@ -666,9 +666,9 @@ case "$1" in
     # Check if user wants to use custom map settings
     if [ $4 ]; then
       if [ -e "${WRITE_DIR}/$4" ]; then
-        createsavecmd="$createsavecmd --map-settings=${WRITE_DIR}/$4"
+        createsavecmd="$createsavecmd --map-settings=${WRITE_DIR}/data/$4"
       else
-        echo "Specified map settings json does not exist"
+        echo "Specified map settings json does not exist in server's /data directory"
         exit 1
       fi
     fi

--- a/factorio
+++ b/factorio
@@ -658,7 +658,7 @@ case "$1" in
       if [ -e "${WRITE_DIR}/$3" ]; then
         createsavecmd="$createsavecmd --map-gen-settings=${WRITE_DIR}/data/$3"
       else
-        echo "Specified map-gen-settings json does not exist in server's /data directory"
+        echo "Specified map-gen-settings json file does not exist in server's /data directory"
         exit 1
       fi
     fi
@@ -668,7 +668,7 @@ case "$1" in
       if [ -e "${WRITE_DIR}/$4" ]; then
         createsavecmd="$createsavecmd --map-settings=${WRITE_DIR}/data/$4"
       else
-        echo "Specified map settings json does not exist in server's /data directory"
+        echo "Specified map-settings json file does not exist in server's /data directory"
         exit 1
       fi
     fi


### PR DESCRIPTION
After multiple problems with understanding where the script is looking for map-gen-settings and map-settings I understood that it was looking in root factorio/directory.

Alternatively I'd like to propose either :
1. Error message specification that the program is looking for the map-gen-settings in factorio root directory
2. Accepting files from any place in the file system via relative or absolute path (unfortunately I lack bash skills to be able to provide solution myself)