### PR TITLE
Fix debug function when used inside function returning a value

### DIFF
--- a/factorio
+++ b/factorio
@@ -12,7 +12,7 @@
 
 function debug() {
   if [ "${DEBUG-0}" -gt 0 ]; then
-    echo "DEBUG: $*"
+    echo "DEBUG: $*" > /dev/tty
   fi
 }
 


### PR DESCRIPTION
Hi,

The debug function sometimes cause problem when used inside function which return a value.

As an example, in the "update" function, we get the version via `version=$(get_bin_version)`.
In `get_bin_version`, we call `as_user` which return the bash output in the main stream.

But if debug is true, the debug function will print the result of `debug "as_user: $1}"` in the main stream and mess up the return value of `as_user` breaking badly the update function : 

```
DEBUG: Invocation: python3 /app/projects/factorio/factorio-updater/update_factorio.py --for-version DEBUG: as_user: /app/projects/factorio/factorio/bin/x64/factorio --version |egrep '^Version: [0-9\.]+' |egrep -o '[0-9\.]+' |head -n 1}   
1.0.0 --package core-linux_headlessDEBUG: as_user: /app/projects/factorio/factorio/bin/x64/factorio --version |egrep '^Binary version: ' |egrep -o '[0-9]{2}'}                                                                                
64 --output-path DEBUG: as_user: mktemp -d -p /tmp factorio-update.XXXXXXXXXX}                                                                                                                                                                
/tmp/factorio-update.qV9meT6jn8 --verbose
```

We can see here the output of the debug function is mixed in.

This fix modify the debug function making it print the debug message in `/dev/tty` (the terminal directly), making the function itself not returning anything and so not messing up with any code calling it.

Tell me what you think about it, `/dev/tty` seems the right solution to me but you may have a better idea ?