### PR TITLE
Fix dockerfiles build for tests

### DIFF
--- a/extras/docker/Dockerfile.centos
+++ b/extras/docker/Dockerfile.centos
@@ -36,27 +36,23 @@ RUN yum groupinstall -y \
 WORKDIR /tmp
 RUN wget -q http://ftp.gnu.org/gnu/glibc/glibc-2.18.tar.gz -O - |tar -xvz
 WORKDIR /tmp/glibc-2.18/glibc-build
+RUN sed "s/3\.\[89\]/3\.\[89\]\* | 4/" -i ../configure
 RUN ../configure --prefix='/opt/glibc-2.18' && \
 	sed -i -e 's#if (/$ld_so_name/) {#if (/\Q$ld_so_name\E/) {#' \
 		../scripts/test-installation.pl && \
 	make && \
 	make install # these take a while (~5 minutes on a i5 3.5GHz 32GB RAM WSL2 box)
+
 USER $factorio_user
 ENV FACTORIO_INIT_ALT_GLIBC=1
 WORKDIR /opt/factorio-init
 
-### and pre-install the game
-FROM with-test-resources AS with-pre-installed-game
-USER root
-RUN tar -xvf /tmp/factorio_headless_x64_${factorio_version}.tar.xz -C /opt && \
-	chown -R ${factorio_user}:${factorio_group} /opt/factorio
-USER ${factorio_user}
-ENV FACTORIO_INIT_WITH_PRE_INSTALLED_GAME=1
-RUN /opt/factorio/bin/x64/factorio --create /opt/factorio/saves/server-save && \
-	cp /opt/factorio/data/server-settings.example.json /opt/factorio/data/server-settings.json
-
 ### and pre-install the game for glibc
 FROM with-glibc-sidebyside AS with-pre-installed-game-glibc
+ARG factorio_user
+ARG factorio_group
+ARG factorio_version
+
 USER root
 RUN tar -xvf /tmp/factorio_headless_x64_${factorio_version}.tar.xz -C /opt && \
 	chown -R ${factorio_user}:${factorio_group} /opt/factorio
@@ -65,4 +61,18 @@ ENV FACTORIO_INIT_WITH_PRE_INSTALLED_GAME=1
 RUN /opt/glibc-2.18/lib/ld-2.18.so --library-path /opt/glibc-2.18/lib \
 	/opt/factorio/bin/x64/factorio --create /opt/factorio/saves/server-save \
 	--executable-path /opt/factorio/bin/x64/factorio && \
+	cp /opt/factorio/data/server-settings.example.json /opt/factorio/data/server-settings.json
+
+### and pre-install the game
+FROM with-test-resources AS with-pre-installed-game
+ARG factorio_user
+ARG factorio_group
+ARG factorio_version
+
+USER root
+RUN tar -xvf /tmp/factorio_headless_x64_${factorio_version}.tar.xz -C /opt && \
+	chown -R ${factorio_user}:${factorio_group} /opt/factorio
+USER ${factorio_user}
+ENV FACTORIO_INIT_WITH_PRE_INSTALLED_GAME=1
+RUN /opt/factorio/bin/x64/factorio --create /opt/factorio/saves/server-save && \
 	cp /opt/factorio/data/server-settings.example.json /opt/factorio/data/server-settings.json

--- a/extras/docker/Dockerfile.ubuntu
+++ b/extras/docker/Dockerfile.ubuntu
@@ -27,6 +27,10 @@ RUN wget -O /tmp/factorio_headless_x64_${factorio_version}.tar.xz \
 
 ### and pre-install the game
 FROM with-test-resources AS with-pre-installed-game
+ARG factorio_version
+ARG factorio_user=factorio
+ARG factorio_group=factorio
+
 USER root
 RUN tar -xvf /tmp/factorio_headless_x64_${factorio_version}.tar.xz -C /opt && \
 	chown -R ${factorio_user}:${factorio_group} /opt/factorio


### PR DESCRIPTION
Hi,
After working on a fix, I tried to run the test cases and I had a hard time... ^^

Here are the modifications to the dockerfiles I had to do in order to be able to run the tests with docker 20.10.2.

In the Dockerfile.ubuntu :
- Add some missing ARG used in a multi stage build. The args are not inherited from a stage to another, you need to declare them in every stage they are used.

In the Dockerfile.centos :
- Add some missing ARG used in a multi stage build.
- Fix the glibc 2.18 installation by allowing the use of `make 4.*`
- Moved the stage `with-pre-installed-game` on the end of file. It is only used by centos8 build and should not be build when using centos7. It is now correctly skipping thanks to the use of `target` in the build command.

Hope it work in your environment too (it should !)