### PR TITLE
Update config.example

### DIFF
--- a/config.example
+++ b/config.example
@@ -25,9 +25,9 @@ FACTORIO_PATH=/opt/factorio
 # Server admin settings
 # Server admin list file, must be in the following format:
 # [
-#    admin1,
-#    admin2,
-#    adminX
+#    "admin1",
+#    "admin2",
+#    "adminX"
 # ]
 # If the file does not exist in ${FACTORIO_PATH}/data, a blank copy will be created.
 ADMINLIST=${FACTORIO_PATH}/data/server-adminlist.json


### PR DESCRIPTION
Added quotation marks around admin names in the server-adminlist.json description so that people not familiar with JSON syntax (like me, for example) will know that they are needed.