### PR TITLE
Forced shutdown timeout from configuration file

### DIFF
--- a/config.example
+++ b/config.example
@@ -56,6 +56,11 @@ SAVELOG=0
 # Useful for Cloud providers where VMs may start faster than their Internet connectivity is plumbed.
 WAIT_PINGPONG=0
 
+# Time after which the factorio server will be killed with force. 
+# Adjust this to allow more time for map saving, e.g. on modded servers with multiple maps.
+# Increased values must be propagated to service files (systemd) as well.
+FORCED_SHUTDOWN=15
+
 # Using install, it's possible to cache the tarballs fetched from Wube
 INSTALL_CACHE_TAR=1
 # set this to a directory where you allow this script to create a 'factorio-install' directory

--- a/factorio
+++ b/factorio
@@ -104,6 +104,10 @@ function config_defaults() {
     WAIT_PINGPONG=0
   fi
 
+  if [ -z "${FORCED_SHUTDOWN}" ]; then
+    FORCED_SHUTDOWN=15
+  fi
+
   if [ -z "${ADMINLIST}" ]; then
     ADMINLIST="${FACTORIO_PATH}/data/server-adminlist.json"
   fi
@@ -332,7 +336,7 @@ function stop_service() {
     echo -n "Stopping ${SERVICE_NAME}: "
     if kill -TERM "$(cat "${PIDFILE}" 2> /dev/null)" 2> /dev/null; then
       sec=1
-      while [ "$sec" -le 15 ]; do
+      while [ "$sec" -le "${FORCED_SHUTDOWN}" ]; do
         if [ -e "${PIDFILE}" ]; then
           if kill -0 "$(cat "${PIDFILE}" 2> /dev/null)" 2> /dev/null; then
             echo -n ". "


### PR DESCRIPTION
This change allows to define the timeout for a forced shutdown in the configuration file. Before this change, the server was killed after a fixed 15 second timeout, which is to small for bigger setups (e.g. multiple map mods like Space Exploration) or slow hardware. Default value in configuration file and if not configured is 15 (the old value).

If changed, the systemd service file must be adjusted as well. This is noted in a comment.

Fixes #191.