### PR TITLE
Adding *.code-workspace to .gitignore Seperate PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config
 **/*.swp
+*.code-workspace


### PR DESCRIPTION
this is the separate PR you requested to add a rule to .gitignore for VS Code users

one of these days ill have github learned properly and not have to do everything in double haha ( stupid ci thing tried to force checks on local machine as well as the runner on my repo....) though for some reason the PR checks fail to start though they run fine on my repo not sure why that is