### PR TITLE
Update factorio.service.example

### DIFF
--- a/extras/factorio.service.example
+++ b/extras/factorio.service.example
@@ -2,6 +2,7 @@
 Description=Factorio Server
 Wants=network-online.target
 After=network.target network-online.target
+StartLimitIntervalSec=600
 
 [Service]
 User=factorio
@@ -18,7 +19,6 @@ TimeoutStopSec=20
 ExecStop=/opt/factorio-init/factorio stop
 RestartSec=20
 Restart=on-failure
-StartLimitIntervalSec=600
 StartLimitBurst=5
 
 [Install]


### PR DESCRIPTION
in 2018, StartLimitIntervalSec=600 is migrated from [Service] to [Unit]

Fix for just a little systemd warning

> Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.

You can verify with
```
$ sudo systemd-analyze verify factorio.service
/etc/systemd/system/./factorio.service:21: Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.
```