### PR TITLE
Change grep to use '-' rather than '_' in factorio server file name

### DIFF
--- a/factorio
+++ b/factorio
@@ -483,7 +483,7 @@ function install(){
     fi
     
     # parse the response
-    if filename=$(echo "${httpresponse}" |grep -oP '(?<=^location: )[^\?]+' |grep -oP 'factorio_headless.+'); then
+    if filename=$(echo "${httpresponse}" |grep -oP '(?<=^location: )[^\?]+' |grep -oP 'factorio-headless.+'); then
       debug "Found, latest version: '${filename}'"
     else
       debug "${httpresponse}"


### PR DESCRIPTION
It looks like the Factorio download uses a hyphen now in the server download - found the issue when first running the install with factorio-init 