### PR TITLE
simple fixes to errors introduced by release/version forward creep

### DIFF
--- a/factorio
+++ b/factorio
@@ -483,7 +483,7 @@ function install(){
     fi
     
     # parse the response
-    if filename=$(echo "${httpresponse}" |grep -oP '(?<=^location: )[^\?]+' |grep -oP 'factorio_headless.+'); then
+    if filename=$(echo "${httpresponse}" |grep -oP '(?<=^location: )[^\?]+' |grep -oPE 'factorio-headless.+|factorio_headless.+'); then
       debug "Found, latest version: '${filename}'"
     else
       debug "${httpresponse}"
@@ -553,11 +553,11 @@ function install(){
 }
 
 function get_bin_version(){
-  as_user "$BINARY --version |egrep '^Version: [0-9\.]+' |egrep -o '[0-9\.]+' |head -n 1"
+  as_user "$BINARY --version |grep -E '^Version: [0-9\.]+' |grep -E -o '[0-9\.]+' |head -n 1"
 }
 
 function get_bin_arch(){
-  as_user "$BINARY --version |egrep '^Binary version: ' |egrep -o '[0-9]{2}'"
+  as_user "$BINARY --version |grep -E '^Version: [0-9\.]+|^Binary' |grep -E -o '[0-9\.]+' |tail -n 1"
 }
 
 function update(){

--- a/factorio
+++ b/factorio
@@ -483,7 +483,7 @@ function install(){
     fi
     
     # parse the response
-    if filename=$(echo "${httpresponse}" |grep -oP '(?<=^location: )[^\?]+' |grep -oPE 'factorio-headless.+|factorio_headless.+'); then
+    if filename=$(echo "${httpresponse}" |grep -oP '(?<=^location: )[^\?]+' |grep -oP 'factorio-headless.+|factorio_headless.+'); then
       debug "Found, latest version: '${filename}'"
     else
       debug "${httpresponse}"


### PR DESCRIPTION
* updating some `egrep` to `grep -E`
* additional match for binary location in `curl` with old filename format
* adding support for new `factorio --version` outputs (Binary version: -> Version:)

These are all just minor technical debt updates.